### PR TITLE
Coverage summary as md file

### DIFF
--- a/APLSource/CodeCoverage.aplc
+++ b/APLSource/CodeCoverage.aplc
@@ -195,6 +195,54 @@
       :EndIf
     ∇
 
+    ∇ mdFilename←ProcessDataAndCreateSummary filename;dcfFilename
+      :Access Public Shared
+      dcfFilename←(⊃,/2↑⎕NPARTS filename),'.profile'
+      'File not found'⎕SIGNAL 11/⍨0=⎕NEXISTS dcfFilename
+      {}ProcessData dcfFilename
+      mdFilename←CreateSummary filename
+    ∇
+
+    ∇ filename←CreateSummary filename;dcfFilename;tno;watched;data;runs;md;tally;caption;table
+      :Access Public Shared
+      dcfFilename←(⊃,/2↑⎕NPARTS filename),'.profile'
+      'File not found'⎕SIGNAL 11/⍨0=⎕NEXISTS dcfFilename
+      tno←dcfFilename ⎕FSTIE 0
+      watched←⎕FREAD tno,2
+      data←⎕FREAD tno 10
+      runs←⎕FREAD tno 4
+      ⎕FUNTIE tno
+      md←⊂'# Coverage Summary'
+      :If 0=≢data
+          md,←⊂'Nothing to report at all'
+      :Else
+          tally←≢data[;4]
+          caption←⊃,/{⍺,', ',⍵}/watched
+          md,←⊂'Watched: ',(⍕tally),' fns/opr within `',caption,'`'
+          md,←⊂''
+          :If 1=≢runs
+              md,←⊂'The test suite was executed once:'
+          :Else
+              md,←⊂'The test suite was executed ',(⍕≢runs),' times:'
+          :EndIf
+          md,←⊂''
+          table←('Executed at' 'APLVersion' 'Memory (MB)'),[0.5]⊂'---'
+          md,←{,/('|',¨⍵),'|'}table⍪runs
+          :If 0<≢∊data[;2 4]
+              md,←⊂''
+              md,←⊂'Overall ',(⍕⌊0.5+100×÷/+⌿≢¨data[;2 4]),'% of the testable code is covered.'
+              md,←⊂''
+              md,←⊂'(Comment lines, empty lines, all `:End`* lines etc. are ignored)'
+          :EndIf
+          md,←⊂''
+          md,←⊂(⍕data[;3]+.=100),' of the fns/opr are 100% covered.'
+          b←~data[;3]∊0 100
+          data←{⍵[⍋⍵[;3];]}data
+      :EndIf
+      filename←(⊃,/2↑⎕NPARTS filename),'.md'
+      (⊂md)⎕NPUT filename 1
+    ∇
+
     ∇ htmlFilename←{verbose}ProcessDataAndCreateReport filename;details;watch;dcfFilename
      ⍝ Takes the name of a component file created by first instantiating `CodeCoverage` and then calling
      ⍝ the instance methods `Start`, `Stop` and `Finalise`.\\

--- a/APLSource/CodeCoverage.aplc
+++ b/APLSource/CodeCoverage.aplc
@@ -204,15 +204,18 @@
     ∇
 
     ∇ filename←CreateSummary filename;dcfFilename;tno;watched;data;runs;md;tally;caption;table
+      ⍝ This function creates an md file containing a summary of the coverage report from the data collected during the execution of an application.\\
+      ⍝ You must call `ProcessData` first: this function relies on the data being aggregated.\\
       :Access Public Shared
       dcfFilename←(⊃,/2↑⎕NPARTS filename),'.profile'
       'File not found'⎕SIGNAL 11/⍨0=⎕NEXISTS dcfFilename
       tno←dcfFilename ⎕FSTIE 0
-      watched←⎕FREAD tno,2
+      watched←⎕FREAD tno 2
       data←⎕FREAD tno 10
       runs←⎕FREAD tno 4
       ⎕FUNTIE tno
       md←⊂'# Coverage Summary'
+      md,←,⊂''
       :If 0=≢data
           md,←⊂'Nothing to report at all'
       :Else
@@ -236,8 +239,6 @@
           :EndIf
           md,←⊂''
           md,←⊂(⍕data[;3]+.=100),' of the fns/opr are 100% covered.'
-          b←~data[;3]∊0 100
-          data←{⍵[⍋⍵[;3];]}data
       :EndIf
       filename←(⊃,/2↑⎕NPARTS filename),'.md'
       (⊂md)⎕NPUT filename 1


### PR DESCRIPTION
Issue: It would be nice to be able to print the coverage report as a job summary in a GitHub workflow. This would be easier if CodeCoverage generated a summary of the report as an md file.

Solution: Added a function to create a summary of the coverage report and save it as an md file. Additionally added the function `ProcessDataAndCreateSummary ` to process and create summary, just like the `ProcessDataAndCreateReport`.